### PR TITLE
Fix division-by-zero if no MX hosts were found

### DIFF
--- a/smtpvalidateclass.php
+++ b/smtpvalidateclass.php
@@ -142,7 +142,7 @@ class SMTP_validateEmail {
      
    $this->debug(print_r($mxs, 1));  
      
-   $timeout = $this->max_conn_time/count($hosts);  
+   $timeout = $this->max_conn_time/(count($hosts)>0 ? count($hosts) : 1);  
       
    // try each host  
    while(list($host) = each($mxs)) {  


### PR DESCRIPTION
Use `noreply@noreply.com` for testing:

``` php
require_once("smtpvalidateclass.php");
$email = array('noreply@noreply.com');
$sender = 'user@example.com';
$SMTP_Valid = new SMTP_validateEmail();
$SMTP_Valid->max_read_time = 2;
$SMTP_Valid->debug = true;
$result = $SMTP_Valid->validate($email, $sender);
var_dump($result);
echo $email . ' is ' . ($result ? 'valid' : 'invalid') . "\n";
```
